### PR TITLE
Fixed Laminas\Log\Writer\Stream not found error

### DIFF
--- a/Model/Request.php
+++ b/Model/Request.php
@@ -13,6 +13,7 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Store\Model\StoreManagerInterface;
 use Partner\Module\Api\ConfigInterface;
+use Partner\Module\Model\Logger\Logger;
 use Partner\Module\Model\System\Config\Mode;
 
 class Request
@@ -40,6 +41,8 @@ class Request
      */
     protected $scopeConfig;
 
+    private Logger $logger;
+
     /**
      * Request constructor.
      *
@@ -51,12 +54,14 @@ class Request
         ConfigInterface $config,
         OrderRepositoryInterface $orderRepository,
         StoreManagerInterface $storeManager,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        Logger $logger
     ) {
         $this->config = $config;
         $this->orderRepository = $orderRepository;
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
+        $this->logger = $logger;
     }
 
     /**
@@ -202,13 +207,8 @@ class Request
 
     public function debuggerOn($str, $requestUri = null)
     {
-
         if ($requestUri == Mode::DEBUG_URL) {
-
-            $writer = new \Laminas\Log\Writer\Stream(BP . '/var/log/Partnerads.log');
-            $logger = new \Laminas\Log\Logger();
-            $logger->addWriter($writer);
-            $logger->info($str);
+            $this->logger->info($str);
         }
     }
 }

--- a/Model/Request.php
+++ b/Model/Request.php
@@ -9,6 +9,7 @@ use Laminas\Http\Client\Adapter\Curl;
 use Laminas\Http\Client as LaminasHttpClient;
 use Laminas\Http\Request as LaminasHttpRequest;
 use Laminas\Stdlib\Parameters as LaminasRequestParameters;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Store\Model\StoreManagerInterface;
@@ -37,7 +38,7 @@ class Request
     private $storeManager;
 
     /**
-     * @var  \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var  ScopeConfigInterface
      */
     protected $scopeConfig;
 
@@ -49,12 +50,14 @@ class Request
      * @param ConfigInterface $config
      * @param OrderRepositoryInterface $orderRepository
      * @param StoreManagerInterface $storeManager
+     * @param ScopeConfigInterface $scopeConfig
+     * @param Logger $logger
      */
     public function __construct(
         ConfigInterface $config,
         OrderRepositoryInterface $orderRepository,
         StoreManagerInterface $storeManager,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        ScopeConfigInterface $scopeConfig,
         Logger $logger
     ) {
         $this->config = $config;


### PR DESCRIPTION
In Magento 2.4.6-p4 we get the error Laminas\Log\Writer\Stream not found error. This is because laminas-log
was removed from Magento. 