### PR TITLE
Fix PartnerAds tracking when running behind Varnish cache

### DIFF
--- a/view/frontend/templates/script.phtml
+++ b/view/frontend/templates/script.phtml
@@ -1,19 +1,13 @@
 <?php
 /** @var \Partner\Module\Block\Script $block */
 ?>
-
 <script type="text/x-magento-init">
     {
         "*": {
-            "Magento_Ui/js/core/app": {
-                "components": {
-                    "partner": {
-                        "component": "Partner_Module/js/partner",
-                        "url": "<?= /** @escapeNotVerified */ $block->getAjaxUrl() ?>",
-                        "partnerId": "<?= /** @escapeNotVerified */ $block->getPartnerId() ?>",
-                        "pacId": "<?= /** @escapeNotVerified */ $block->getPacId() ?>"
-                    }
-                }
+            "Partner_Module/js/partner": {
+                "url": "<?= /** @escapeNotVerified */ $block->getAjaxUrl() ?>",
+                "partnerId": "<?= /** @escapeNotVerified */ $block->getPartnerId() ?>",
+                "pacId": "<?= /** @escapeNotVerified */ $block->getPacId() ?>"
             }
         }
     }

--- a/view/frontend/web/js/partner.js
+++ b/view/frontend/web/js/partner.js
@@ -1,24 +1,82 @@
 define([
-    'uiComponent',
     'jquery'
-], function (Component, $) {
+], function ($) {
     'use strict';
 
-    return Component.extend({
-
-        initialize: function (config) {
-
-            $.ajax({
-                url: config.url,
-                data: {
-                    'partnerId': config.partnerId,
-                    'pacId': config.pacId
-                },
-                type: 'GET',
-                global: true,
-                contentType: 'application/json',
-                cache: false
-            });
+    function decode(value) {
+        try {
+            return decodeURIComponent((value || '').replace(/\+/g, ' '));
+        } catch (e) {
+            return value;
         }
-    });
+    }
+
+    function parseSearchLegacy(search) {
+        var result = {};
+        var query = search || '';
+        var pairs;
+        var i;
+        var pair;
+        var key;
+        var value;
+
+        if (!query || query.length < 2) {
+            return result;
+        }
+
+        pairs = query.substring(1).split('&');
+
+        for (i = 0; i < pairs.length; i++) {
+            if (!pairs[i]) {
+                continue;
+            }
+
+            pair = pairs[i].split('=');
+            key = decode(pair[0] || '');
+            value = decode(pair.length > 1 ? pair.slice(1).join('=') : '');
+
+            if (key) {
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    function getQueryParam(name) {
+        var params;
+
+        if (window.URLSearchParams) {
+            params = new URLSearchParams(window.location.search || '');
+            return params.has(name) ? params.get(name) : '';
+        }
+
+        params = parseSearchLegacy(window.location.search || '');
+
+        return params[name] || '';
+    }
+
+    return function (config) {
+        var partnerIdFromUrl = getQueryParam('pa-partnerid');
+        var pacIdFromUrl = getQueryParam('pacid');
+        var hasServerValues = !!(config.partnerId || config.pacId);
+        var partnerId = hasServerValues ? (config.partnerId || '') : (partnerIdFromUrl || '');
+        var pacId = hasServerValues ? (config.pacId || '') : (pacIdFromUrl || '');
+
+        if (!partnerId && !pacId) {
+            return;
+        }
+
+        $.ajax({
+            url: config.url,
+            data: {
+                'partnerId': partnerId,
+                'pacId': pacId
+            },
+            type: 'GET',
+            global: true,
+            contentType: 'application/json',
+            cache: false
+        });
+    };
 });


### PR DESCRIPTION
## Problem
When Magento 2 runs behind a Varnish cache, the `pa-partnerid` and `pacid` URL parameters are stripped before they reach the PHP backend. This means the tracking block renders with empty partner/pac IDs, and the AJAX call to register the visit is never made. Affiliate tracking is effectively broken for all cached pages.

## Solution
This PR adds a client-side JavaScript fallback that reads `pa-partnerid` and `pacid` directly from the URL when the server-side values are empty. If the backend provides values (non-Varnish scenario), those are still used as before.

## Changes

**`view/frontend/templates/script.phtml`**
- Simplified the initialization from `Magento_Ui/js/core/app` component approach to a direct `x-magento-init` widget call, reducing unnecessary overhead.

**`view/frontend/web/js/partner.js`**
- Removed `uiComponent` dependency — no longer needed since we use a simple widget function.
- Added URL query parameter parsing with `URLSearchParams` and a legacy fallback for older browsers.
- If server-side `partnerId`/`pacId` are empty, the script reads them from the current URL instead.
- If neither source provides values, the AJAX call is skipped entirely.

## Tested on
- Magento 2.4.8 with Varnish enabled
- Magento 2.4.8 without Varnish (backwards compatible)