### PR TITLE
Fix partner tracking params on cached pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "partnerads/magento2",
   "description": "Magento 2 module for tracking affilate sales through Partner Ads network",
   "type": "magento2-module",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": [
     "proprietary"
   ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Partner_Module" setup_version="2.3.0">
+    <module name="Partner_Module" setup_version="2.3.1">
         <sequence>
         </sequence>
     </module>

--- a/view/frontend/web/js/partner.js
+++ b/view/frontend/web/js/partner.js
@@ -57,11 +57,12 @@ define([
     }
 
     return function (config) {
+        config = config || {};
+
         var partnerIdFromUrl = getQueryParam('pa-partnerid');
         var pacIdFromUrl = getQueryParam('pacid');
-        var hasServerValues = !!(config.partnerId || config.pacId);
-        var partnerId = hasServerValues ? (config.partnerId || '') : (partnerIdFromUrl || '');
-        var pacId = hasServerValues ? (config.pacId || '') : (pacIdFromUrl || '');
+        var partnerId = partnerIdFromUrl || config.partnerId || '';
+        var pacId = pacIdFromUrl || config.pacId || '';
 
         if (!partnerId && !pacId) {
             return;
@@ -71,7 +72,8 @@ define([
             url: config.url,
             data: {
                 'partnerId': partnerId,
-                'pacId': pacId
+                'pacId': pacId,
+                '_': Date.now()
             },
             type: 'GET',
             global: true,


### PR DESCRIPTION
Prefer tracking parameters from the current URL before falling back to server-rendered config values, and add a cache-busting value to the cookie AJAX request.

Bump module version to 2.3.1.